### PR TITLE
Fix GitHub Pages 404

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0; URL=swagger/dist/index.html">
+  </head>
+  <body>
+    <p>Redirecting to <a href="swagger/dist/index.html">API documentation</a>...</p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add redirecting index.html so GitHub Pages loads API docs

## Testing
- `npm test` *(fails: Could not read package.json)*
- `bundle exec rspec` *(fails: Could not locate Gemfile)*

------
https://chatgpt.com/codex/tasks/task_e_6873333a9ae883208b67432cbcdb631e