### PR TITLE
Add response examples to API specs

### DIFF
--- a/spec/requests/api/v1/sessions_spec.rb
+++ b/spec/requests/api/v1/sessions_spec.rb
@@ -23,11 +23,23 @@ RSpec.describe 'Sessions API', swagger_doc: 'v1/swagger.yaml', type: :request do
         run_test! do |response|
           expect(JSON.parse(response.body)).to have_key('token')
         end
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
       end
 
       response(401, '認証失敗') do
         let(:credentials) { { email: 'tester@example.com', password: 'wrong' } }
         run_test!
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => { example: response.body.presence }
+          }
+        end
       end
     end
   end

--- a/spec/requests/api/v1/training_records_spec.rb
+++ b/spec/requests/api/v1/training_records_spec.rb
@@ -23,6 +23,13 @@ RSpec.describe "TrainingRecords API", swagger_doc: 'v1/swagger.yaml', type: :req
         run_test! do |response|
           expect(JSON.parse(response.body).length).to eq(1)
         end
+        after do |example|
+          example.metadata[:response][:content] = {
+            "application/json" => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
       end
 
       response(401, "未認証") do
@@ -49,8 +56,15 @@ RSpec.describe "TrainingRecords API", swagger_doc: 'v1/swagger.yaml', type: :req
         let(:training_menu_id) { menu.id }
         let(:Authorization) { "Bearer #{token}" }
         let(:training_record) { { count: 30, recorded_at: Time.current } }
-        run_test! do
+        run_test! do |response|
           expect(TrainingRecord.count).to eq(1)
+        end
+        after do |example|
+          example.metadata[:response][:content] = {
+            "application/json" => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
         end
       end
 
@@ -59,12 +73,26 @@ RSpec.describe "TrainingRecords API", swagger_doc: 'v1/swagger.yaml', type: :req
         let(:Authorization) { "Bearer #{token}" }
         let(:training_record) { { recorded_at: nil } }
         run_test!
+        after do |example|
+          example.metadata[:response][:content] = {
+            "application/json" => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
       end
 
       response(401, "未認証") do
         let(:training_menu_id) { menu.id }
         let(:training_record) { { count: 10, recorded_at: Time.current } }
         run_test!
+        after do |example|
+          example.metadata[:response][:content] = {
+            "application/json" => {
+              example: response.body.presence
+            }
+          }
+        end
       end
     end
   end

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -18,14 +18,28 @@ RSpec.describe 'Users API', swagger_doc: 'v1/swagger.yaml', type: :request do
 
       response(201, '作成成功') do
         let(:user) { { user: { name: 'tester', email: 'tester@example.com', password: 'secret', password_confirmation: 'secret' } } }
-        run_test! do
+        run_test! do |response|
           expect(User.last.role).to eq(1)
+        end
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
         end
       end
 
       response(422, '不正なパラメータ') do
         let(:user) { { user: { name: '' } } }
         run_test!
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary
- update request specs to store example responses in Swagger docs

## Testing
- `bundle exec rubocop -a`
- `bundle exec rspec`

------
https://chatgpt.com/codex/tasks/task_e_687583643d388320872e970064b564f3