### PR TITLE
種目ごとのランキングAPIの追加

### DIFF
--- a/app/controllers/api/v1/rankings_controller.rb
+++ b/app/controllers/api/v1/rankings_controller.rb
@@ -1,0 +1,19 @@
+module Api
+  module V1
+    class RankingsController < ApplicationController
+      before_action :set_training_menu
+
+      def index
+        period = params[:period]&.downcase || "total"
+        rankings = RankingService.new(@training_menu, period: period).call
+        render json: rankings
+      end
+
+      private
+
+      def set_training_menu
+        @training_menu = TrainingMenu.find(params[:training_menu_id])
+      end
+    end
+  end
+end

--- a/app/services/ranking_service.rb
+++ b/app/services/ranking_service.rb
@@ -1,0 +1,32 @@
+class RankingService
+  PERIODS = %w[weekly monthly total].freeze
+
+  def initialize(training_menu, period: "total", now: Time.zone.now)
+    @training_menu = training_menu
+    @period = PERIODS.include?(period) ? period : "total"
+    @now = now
+  end
+
+  def call
+    records = @training_menu.training_records
+    records = case @period
+    when "weekly"
+                range = @now.beginning_of_week(:monday)..@now.end_of_week(:monday)
+                records.where(recorded_at: range)
+    when "monthly"
+                range = @now.beginning_of_month..@now.end_of_month
+                records.where(recorded_at: range)
+    else
+                records
+    end
+
+    records
+      .joins(:user)
+      .group("users.id", "users.name")
+      .select("users.id AS user_id, users.name AS name, SUM(training_records.count) AS total_count")
+      .order("total_count DESC")
+      .map.with_index(1) do |r, index|
+        { rank: index, user_id: r.user_id, name: r.name, total_count: r.total_count.to_i }
+      end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
       resources :users, only: [ :create ]
       resources :training_menus, only: [] do
         resources :training_records, only: [ :index, :create ]
+        get :rankings, to: "rankings#index"
       end
     end
   end

--- a/spec/requests/api/v1/rankings_spec.rb
+++ b/spec/requests/api/v1/rankings_spec.rb
@@ -1,0 +1,53 @@
+require 'swagger_helper'
+
+RSpec.describe "Rankings API", swagger_doc: 'v1/swagger.yaml', type: :request do
+  let!(:user1) { User.create!(name: "user1", email: "user1@example.com", password: "secret", password_confirmation: "secret") }
+  let!(:user2) { User.create!(name: "user2", email: "user2@example.com", password: "secret", password_confirmation: "secret") }
+  let!(:menu) { TrainingMenu.create!(name: "menu", rule: "rule") }
+  let(:token) { JWT.encode({ sub: user1.id }, Rails.application.secret_key_base, 'HS256') }
+  let(:headers) { { 'Authorization' => "Bearer #{token}" } }
+
+  path "/api/v1/training_menus/{training_menu_id}/rankings" do
+    parameter name: :training_menu_id, in: :path, type: :string, description: 'メニューID'
+    parameter name: :period, in: :query, type: :string, required: false, description: 'weekly, monthly, total'
+    parameter name: :Authorization, in: :header, type: :string, required: false
+
+    get "ランキング取得" do
+      tags "Rankings"
+      produces "application/json"
+
+      response(200, "成功") do
+        let(:training_menu_id) { menu.id }
+        let(:period) { 'total' }
+        let(:Authorization) { "Bearer #{token}" }
+        before do
+          TrainingRecord.create!(user: user1, training_menu: menu, count: 10, recorded_at: Time.current)
+          TrainingRecord.create!(user: user2, training_menu: menu, count: 20, recorded_at: Time.current)
+        end
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data.first['user_id']).to eq(user2.id)
+        end
+        after do |example|
+          example.metadata[:response][:content] = {
+            "application/json" => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+      end
+
+      response(401, "未認証") do
+        let(:training_menu_id) { menu.id }
+        run_test!
+        after do |example|
+          example.metadata[:response][:content] = {
+            "application/json" => {
+              example: response.body.presence
+            }
+          }
+        end
+      end
+    end
+  end
+end

--- a/spec/services/ranking_service_spec.rb
+++ b/spec/services/ranking_service_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe RankingService, type: :service do
+  let(:menu) { TrainingMenu.create!(name: 'menu', rule: 'rule') }
+  let(:user1) { User.create!(name: 'user1', email: 'user1@example.com', password: 'secret', password_confirmation: 'secret') }
+  let(:user2) { User.create!(name: 'user2', email: 'user2@example.com', password: 'secret', password_confirmation: 'secret') }
+  let(:now) { Time.zone.local(2024, 6, 24, 12) }
+
+  describe '#call' do
+    it 'calculates weekly ranking' do
+      TrainingRecord.create!(user: user1, training_menu: menu, count: 10, recorded_at: now)
+      TrainingRecord.create!(user: user2, training_menu: menu, count: 20, recorded_at: now + 1.day)
+      TrainingRecord.create!(user: user1, training_menu: menu, count: 30, recorded_at: now - 8.days)
+
+      result = described_class.new(menu, period: 'weekly', now: now).call
+
+      expect(result.size).to eq(2)
+      expect(result.first[:user_id]).to eq(user2.id)
+      expect(result.first[:total_count]).to eq(20)
+    end
+
+    it 'calculates monthly ranking excluding other months' do
+      TrainingRecord.create!(user: user1, training_menu: menu, count: 15, recorded_at: now.beginning_of_month + 1.day)
+      TrainingRecord.create!(user: user2, training_menu: menu, count: 5, recorded_at: now.end_of_month - 1.day)
+      TrainingRecord.create!(user: user2, training_menu: menu, count: 50, recorded_at: now - 1.month)
+
+      result = described_class.new(menu, period: 'monthly', now: now).call
+
+      expect(result.size).to eq(2)
+      expect(result.first[:user_id]).to eq(user1.id)
+      expect(result.first[:total_count]).to eq(15)
+    end
+
+    it 'calculates total ranking' do
+      TrainingRecord.create!(user: user1, training_menu: menu, count: 10, recorded_at: now)
+      TrainingRecord.create!(user: user2, training_menu: menu, count: 20, recorded_at: now)
+      TrainingRecord.create!(user: user1, training_menu: menu, count: 30, recorded_at: now - 2.months)
+
+      result = described_class.new(menu, period: 'total', now: now).call
+
+      expect(result.first[:user_id]).to eq(user1.id)
+      expect(result.first[:total_count]).to eq(40)
+    end
+  end
+end


### PR DESCRIPTION
## 概要
- 種目別の週間・月間・通算ランキングを取得するAPIを追加
- ランキング計算用のサービスを実装
- ランキングAPIのリクエストスペックとサービスのユニットテストを追加

## テスト
- `bundle exec rubocop -a`
- `bundle exec rspec`


------
https://chatgpt.com/codex/tasks/task_e_68c7577ab2588320bdf46de31eedc0c5